### PR TITLE
Add unique index

### DIFF
--- a/snsims/simulations.py
+++ b/snsims/simulations.py
@@ -5,7 +5,6 @@ import abc
 
 from opsimsummary import Tiling, HealpixTiles
 from analyzeSN import LightCurve
-from analyzeSN import Photometry
 from .universe import Universe
 from .paramDistribution import SimpleSALTDist
 import os
@@ -16,6 +15,17 @@ from lsst.sims.catUtils.supernovae import SNObject
 
 __all__ = ['SimulationTile', 'EntireSimulation', 'TiledSimulation']
 
+class Photometry(object):
+    """
+    Temporary class standing in for the Photometry class in AnalyzeSN which is
+    currently in a branch
+    """
+    def __init__(self):
+        pass
+
+    @staticmethod
+    def  pair_method(obsHistID, snid, maxObsHistID):
+        return snid * maxObsHistID + obsHistID
 class EntireSimulation(Universe):
     """
     Simulation of a set of SN from a set of telescope pointings


### PR DESCRIPTION
Added the ability to add a unique index to each observation of an object in the class `EntireSimulation` This uses a temporary class `Photometry` which has a single static function. It is a standing for the class `Photometry` in `AnalyzeSN` which is yet to be merged. Closes #65 